### PR TITLE
Bug fixes to abstraction layer

### DIFF
--- a/lib/HighLevelSwitch0x01.ml
+++ b/lib/HighLevelSwitch0x01.ml
@@ -80,26 +80,27 @@ module Common = HighLevelSwitch_common.Make (struct
     let open OpenFlow0x01_Core in
     match act with
       | OutputAllPorts -> (Mod.none, Output AllPorts)
-      | OutputPort (VInt.Int16 n) ->
+      | OutputPort n ->
+	let n = VInt.get_int16 n in 
         if Some n = inPort then
           (Mod.none, Output InPort)
         else
           (Mod.none, Output (PhysicalPort n))
-      | OutputPort _ -> raise (Invalid_argument "expected OpenFlow 1.0 port number")
       | SetField (AL.InPort, _) -> raise (Invalid_argument "cannot set input port")
       | SetField (EthType, _) -> raise (Invalid_argument "cannot set frame type")
-      | SetField (EthSrc, VInt.Int48 n) -> (Mod.dlSrc, SetDlSrc n)
-      | SetField (EthDst, VInt.Int48 n) -> (Mod.dlDst , SetDlDst n)
-      | SetField (Vlan, VInt.Int16 0xFFFF) -> (Mod.dlVlan, SetDlVlan None)
-      | SetField (Vlan, VInt.Int16 n) -> (Mod.dlVlan, SetDlVlan (Some n))
-      | SetField (VlanPcp, VInt.Int4 n) -> (Mod.dlVlanPcp, SetDlVlanPcp n)
+      | SetField (EthSrc, n) -> (Mod.dlSrc, SetDlSrc (VInt.get_int48 n))
+      | SetField (EthDst, n) -> (Mod.dlDst , SetDlDst (VInt.get_int48 n))
+      | SetField (Vlan, n) -> 
+	begin match VInt.get_int16 n with 
+	  | 0xFFFF -> (Mod.dlVlan, SetDlVlan None)
+	  | n -> (Mod.dlVlan, SetDlVlan (Some n))
+	end
+      | SetField (VlanPcp, n) -> (Mod.dlVlanPcp, SetDlVlanPcp (VInt.get_int4 n))
       | SetField (IPProto, _) -> raise (Invalid_argument "cannot set IP protocol")
-      | SetField (IP4Src, VInt.Int32 n) -> (Mod.nwSrc, SetNwSrc n)
-      | SetField (IP4Dst, VInt.Int32 n) -> (Mod.nwDst, SetNwDst n)
-      | SetField (TCPSrcPort, VInt.Int16 n) -> (Mod.tpSrc, SetTpSrc n)
-      | SetField (TCPDstPort, VInt.Int16 n) -> (Mod.tpDst, SetTpDst n)
-      | SetField _ -> raise (Invalid_argument "invalid SetField combination")
-
+      | SetField (IP4Src, n) -> (Mod.nwSrc, SetNwSrc (VInt.get_int32 n))
+      | SetField (IP4Dst, n) -> (Mod.nwDst, SetNwDst (VInt.get_int32 n))
+      | SetField (TCPSrcPort, n) -> (Mod.tpSrc, SetTpSrc (VInt.get_int16 n))
+      | SetField (TCPDstPort, n) -> (Mod.tpDst, SetTpDst (VInt.get_int16 n))
 end)
 
 let from_group (inPort : Core.portId option) (group : AL.group) : Core.action list =

--- a/lib/HighLevelSwitch_common.ml
+++ b/lib/HighLevelSwitch_common.ml
@@ -31,23 +31,22 @@ module type S = sig
   type of_action = OF.of_action
   type of_portId = OF.of_portId
 
-
 	(* Converts an abstract action sequence to an OpenFlow action sequence *)
 	let rec from_seq (inPort : OF.of_portId option) (seq : SDN.seq) 
 	  : Mod.t * OF.of_action list =
-	  let f act (mods, of_seq) = 
+	  let f (mods, of_seq) act= 
 	    let (mods', of_act) = OF.from_action inPort act in
-	    (Mod.seq mods' mods, of_act :: of_seq) in
-	  List.fold_right f seq (Mod.none, [])
+	    (Mod.seq mods mods', of_act :: of_seq) in
+	  List.fold_left f (Mod.none, []) seq 
 
 	(* Converts abstract action union to an OF 1.0 action sequence. This may
 	   trigger exceptions if the parallel composition is unrealizable. *)
 	let rec from_par (inPort : OF.of_portId option) (par : SDN.par) :
 	  Mod.t * OF.of_action list =
-	  let f act (mods, of_seq) =
+	  let f (mods, of_seq) act =
 	    let (mods', of_act) = from_seq inPort act in
-	    (Mod.par mods' mods, of_act @ of_seq) in
-	  List.fold_right f par (Mod.none, [])
+	    (Mod.par mods mods', of_act @ of_seq) in
+	  List.fold_left f (Mod.none, []) par 
 
 	let rec flatten_par (inPort : OF.of_portId option) (par : SDN.par) 
 	  : OF.of_action list =

--- a/lib/ModComposition.ml
+++ b/lib/ModComposition.ml
@@ -48,19 +48,19 @@ let seq (m1 : t) (m2 : t) = {
 }
 
 let override (x : bool) (y : bool) : bool =
-	match (x, y) with
-	  | (true, false) -> raise (Invalid_argument "unrealizable modification")
-	  | (true, true) -> true
-	  | (false, _) -> y
+  match (x, y) with
+    | (true, false) -> 
+      raise (Invalid_argument "unrealizable modification")
+    | (true, true) -> true
+    | (false, _) -> y
 
 let par (m1 : t) (m2 : t) = {
-	dlSrc = override m1.dlSrc m2.dlSrc;
-	dlDst = override m2.dlDst m2.dlDst;
-	dlVlan = override m1.dlVlan m2.dlVlan;
-	dlVlanPcp = override m1.dlVlanPcp m2.dlVlanPcp;
-	nwSrc = override m1.nwSrc m2.nwSrc;
-	nwDst = override m1.nwDst m2.nwDst;
-	tpSrc = override m1.tpSrc m2.tpSrc;
-	tpDst = override m1.tpDst m2.tpDst
-	
+  dlSrc = override m1.dlSrc m2.dlSrc;
+  dlDst = override m1.dlDst m2.dlDst;
+  dlVlan = override m1.dlVlan m2.dlVlan;
+  dlVlanPcp = override m1.dlVlanPcp m2.dlVlanPcp;
+  nwSrc = override m1.nwSrc m2.nwSrc;
+  nwDst = override m1.nwDst m2.nwDst;
+  tpSrc = override m1.tpSrc m2.tpSrc;
+  tpDst = override m1.tpDst m2.tpDst
 }

--- a/lib/SDN_Types.mli
+++ b/lib/SDN_Types.mli
@@ -144,7 +144,12 @@ type flowStats = {
 
 (* {1 Pretty-printing } *)
 
+val format_action : Format.formatter -> action -> unit
+val format_seq : Format.formatter -> seq -> unit
+val format_par : Format.formatter -> par -> unit
+val format_group : Format.formatter -> group -> unit
 val format_field : Format.formatter -> field -> unit
+val format_flow : Format.formatter -> flow -> unit
 val format_flowTable : Format.formatter -> flowTable -> unit
 
 module type SWITCH = sig


### PR DESCRIPTION
This commit fixes a number of bugs in the abstraction layer:
- in `ModComposition.par`, `m1` and `m2` were used inconsistently.
- in `HighLevelSwitch_common.from_par` and `HighLevelSwitch_common.from_seq`, `List.fold_left` was wanted instead of `List.fold_right`
- in `HighLevelSwitch0x01.from_action` coercions frmo VInt were failing for parsed NetKAT expressions.

It also exposes a few more pretty printing functions from SDN_Types to aid debugging.
