### PR TITLE
Vlan fix

### DIFF
--- a/lib/HighLevelSwitch0x04.ml
+++ b/lib/HighLevelSwitch0x04.ml
@@ -61,7 +61,8 @@ let from_pattern (pat : AL.pattern) : Core.oxmMatch * Core.portId option =
      @ (lookup (fun x -> Core.OxmEthDst (v_to_m (VInt.get_int48 x))) AL.EthDst) 
      @ (lookup (fun x -> Core.OxmEthType (VInt.get_int16 x)) AL.EthType)
      @ (try match VInt.get_int16 (Fields.find AL.Vlan pat) with
-       | 0xFFFF -> []
+       | -1 -> [Core.OxmVlanVId {Core.m_value = 0x1000; Core.m_mask = Some 0x1000}]
+       | 0xFFFF -> [Core.OxmVlanVId (v_to_m 0)]
        | x -> [ Core.OxmVlanVId (v_to_m x) ]
        with Not_found -> [])
      @ (lookup (fun x -> Core.OxmVlanPcp (VInt.get_int4 x)) AL.VlanPcp)


### PR DESCRIPTION
Splits rules that pop_vlan and don't match on VLAN into two rules: one that matches on vlan_any and pops, and one that matches on vlan_none and doesn't pop. Uses VLAN_VID = -1 to encode "vlan_any" to 0x04 backend.
