### PR TITLE
Fix bug in pattern formatting

### DIFF
--- a/lib/SDN_Types.ml
+++ b/lib/SDN_Types.ml
@@ -118,10 +118,11 @@ let format_pattern (fmt:Format.formatter) (p:pattern) : unit =
   Format.fprintf fmt "@[{";
   let _ = 
     FieldMap.fold 
-      (fun f v b -> format_field fmt f; 
+      (fun f v b ->
+        if b then Format.fprintf fmt ",@,";
+        format_field fmt f;
         Format.fprintf fmt "="; 
         VInt.format fmt v; 
-        if b then Format.fprintf fmt ",@,";
         true)
       p false in 
   Format.fprintf fmt "@]"


### PR DESCRIPTION
Commas were being misplaced, leading to output like this:

```
    pattern={InPort=1Vlan=7,, ...
```

This patch fixes this and produces out like this:

```
    pattern={InPort=1,Vlan=7, ...
```

Any pattern with more than filter should exercise this bug. For a quick
example, use the katnetic binary in the frenetic repo and run it on a
policy.
