### PR TITLE
fix OF 1.0 switch handshake

### DIFF
--- a/lib/OpenFlow0x01_Switch.ml
+++ b/lib/OpenFlow0x01_Switch.ml
@@ -85,6 +85,8 @@ let switch_handshake (fd : file_descr) : OF.SwitchFeatures.t option Lwt.t =
       | None ->
         Lwt.return None
 *)
+    | _ ->
+      Lwt.return None
     end
   | false -> 
     Lwt.return None


### PR DESCRIPTION
dff1bfa466d86c16c628e83e6441714e2601bcd8 broke the OF 1.0 switch handshake. this definitely affects controllers which use OpenFlow0x01_Platform.ml explicitly, and may affect controllers using SDN.ml as well. (notice that the handling of the Hello message from the switch got crunched)
