### PR TITLE
Changed bytes type from string to Cstruct.t

### DIFF
--- a/lib/SDN_Types.ml
+++ b/lib/SDN_Types.ml
@@ -9,7 +9,7 @@ type int16 = int
 type int32 = Int32.t
 type int64 = Int64.t
 type int48 = Int64.t
-type bytes = string
+type bytes = Cstruct.t
 
 type switchId = VInt.t
 type portId = VInt.t

--- a/lib/SDN_Types.mli
+++ b/lib/SDN_Types.mli
@@ -35,7 +35,7 @@ type int16 = int
 type int32 = Int32.t
 type int64 = Int64.t
 type int48 = Int64.t
-type bytes = string
+type bytes = Cstruct.t
 
 type switchId = VInt.t
 type portId = VInt.t

--- a/lwt/HighLevelSwitch0x01.ml
+++ b/lwt/HighLevelSwitch0x01.ml
@@ -16,16 +16,16 @@ let to_payload (pay : Core.payload) : AL.payload =
   let open Core in
   match pay with
     | Buffered (buf_id, ct) ->
-      AL.Buffered (AL.OF10BufferId buf_id, Cstruct.to_string ct)
+      AL.Buffered (AL.OF10BufferId buf_id, ct)
     | NotBuffered ct ->
-      AL.NotBuffered (Cstruct.to_string ct)
+      AL.NotBuffered ct
 	
 let from_payload (pay : AL.payload) : Core.payload =
   let open SDN_Types in
   match pay with
     | Buffered (buf_id, bytes) ->
-      Core.Buffered (from_buffer_id buf_id, Cstruct.of_string bytes)
-    | NotBuffered bytes -> Core.NotBuffered (Cstruct.of_string bytes)
+      Core.Buffered (from_buffer_id buf_id, bytes)
+    | NotBuffered bytes -> Core.NotBuffered bytes
       
 let from_port (port : AL.port) : Core.pseudoPort =
   let open SDN_Types in

--- a/lwt/HighLevelSwitch0x04.ml
+++ b/lwt/HighLevelSwitch0x04.ml
@@ -16,16 +16,16 @@ let to_payload (pay : Core.payload) : AL.payload =
   let open Core in
   match pay with
     | Buffered (buf_id, ct) ->
-      AL.Buffered (AL.OF10BufferId buf_id, Cstruct.to_string ct)
+      AL.Buffered (AL.OF10BufferId buf_id, ct)
     | NotBuffered ct ->
-      AL.NotBuffered (Cstruct.to_string ct)
+      AL.NotBuffered ct
   
 let from_payload (pay : AL.payload) : Core.payload =
   let open SDN_Types in
   match pay with
     | Buffered (buf_id, bytes) ->
-      Core.Buffered (from_buffer_id buf_id, Cstruct.of_string bytes)
-    | NotBuffered bytes -> Core.NotBuffered (Cstruct.of_string bytes)
+      Core.Buffered (from_buffer_id buf_id, bytes)
+    | NotBuffered bytes -> Core.NotBuffered bytes
       
 let from_port (port : AL.port) : Core.pseudoPort =
   let open SDN_Types in


### PR DESCRIPTION
Packet exposes Cstruct.t, which we were then converting to string, which then needed to be converted back to Cstruct.t before parsing or using otherwise.
