### PR TITLE
Fix conformance to specifications for Set-Field VLAN_VID

### DIFF
--- a/lib/HighLevelSwitch0x04.ml
+++ b/lib/HighLevelSwitch0x04.ml
@@ -112,7 +112,7 @@ module Common = HighLevelSwitch_common.Make (struct
                                 match n with
                                   | 0xFFFF -> (Mod.dlVlan, Core.PopVlan)
                                   | -1 -> (Mod.dlVlan, Core.PushVlan)
-                                  | _ -> (Mod.dlVlan, Core.SetField (OxmVlanVId (v_to_m n)))
+                                  | _ -> (Mod.dlVlan, Core.SetField (OxmVlanVId (v_to_m (n lor 0x1000 (*OFPVID_PRESENT*) ))))
                               end
       | SetField (VlanPcp, n) -> let n = VInt.get_int4 n in
                                  (Mod.dlVlanPcp, Core.SetField (OxmVlanPcp n))


### PR DESCRIPTION
OpenFlow Specification 1.3.3 (https://www.opennetworking.org/images/stories/downloads/sdn-resources/onf-specifications/openflow/openflow-spec-v1.3.3.pdf), p. 65:
"The value in the payload of the OXM TLV must be valid, in particular the OFPVID_PRESENT bit must be set in OXM_OF_VLAN_VID set-field actions."
