### PR TITLE
fix bug in build/test script

### DIFF
--- a/.travis-ci.sh
+++ b/.travis-ci.sh
@@ -30,7 +30,7 @@ eval `opam config env`
 
 for dep in ${GITHUB_DEPENDS}; do
     git clone "https://github.com/frenetic-lang/$dep" &&
-        (cd "$dep" && echo "$dep HEAD" && git show --pretty="format:%H" &&
+        (cd "$dep" && echo "$dep HEAD" && git rev-parse HEAD &&
          ocaml setup.ml -configure && make && make install)
 done
 


### PR DESCRIPTION
The script was previously using `git show --pretty=format:%H` to print
out the commit hash of dependencies checked out of github. But also,
this command will still prints out the commit diff. For merge commits,
and non-merge commits whose diff isn't long enough for require the use
of a pager, this is not a problem. However, if the commit diff is long
enough that git pipes it to a pager, it will cause the build to hang.
Instead of using `git show`, the script now uses `git rev-parse HEAD`,
which will only print out the commit hash of HEAD.
