### PR TITLE
fd-leak: Add unnamed argument to create functions

### DIFF
--- a/async/Async_Highlevel.ml
+++ b/async/Async_Highlevel.ml
@@ -165,8 +165,12 @@ let features t evt =
         return None
      end
 
-let create (port:int) : t Deferred.t =
-  Platform.create port
+let create ?max_pending_connections
+    ?verbose
+    ?log_disconnects
+    ?buffer_age_limit ~port () =
+  Platform.create ?max_pending_connections ?verbose ?log_disconnects
+    ?buffer_age_limit ~port ()
   >>| function t ->
       Log.info ~tags "accepting switches on port %d" port;
       { sub = t

--- a/async/Async_OpenFlow.mli
+++ b/async/Async_OpenFlow.mli
@@ -47,6 +47,7 @@ module Platform : sig
       -> ?log_disconnects:bool
       -> ?buffer_age_limit:[ `At_most of Time.Span.t | `Unlimited ]
       -> port:int
+      -> unit
       -> t Deferred.t
 
     val listen : t -> e Pipe.Reader.t
@@ -169,7 +170,14 @@ end
 module Highlevel : sig
   type t
 
-  val create : int -> t Deferred.t
+  val create
+    :  ?max_pending_connections:int
+    -> ?verbose:bool (** default is [false] *)
+    -> ?log_disconnects:bool (** default is [true] *)
+    -> ?buffer_age_limit:[ `At_most of Time.Span.t | `Unlimited ]
+    -> port:int
+    -> unit
+    -> t Deferred.t
   val accept_switches : t -> SDN_Types.switchFeatures Pipe.Reader.t
 
   val setup_flow_table

--- a/async/Async_OpenFlow0x01.ml
+++ b/async/Async_OpenFlow0x01.ml
@@ -58,9 +58,12 @@ module Controller = struct
         end
       | `Disconnect e -> return (Some(`Disconnect e))
 
-  let create ?max_pending_connections ?verbose ?log_disconnects ?buffer_age_limit ~port =
+  let create ?max_pending_connections
+      ?verbose
+      ?log_disconnects
+      ?buffer_age_limit ~port () =
     ChunkController.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port
+      ?buffer_age_limit ~port ()
     >>| function t -> { sub = t }
 
   let listen t =

--- a/async/Async_OpenFlow0x04.ml
+++ b/async/Async_OpenFlow0x04.ml
@@ -57,9 +57,12 @@ module Controller = struct
         end
       | `Disconnect e -> return (Some(`Disconnect e))
 
-  let create ?max_pending_connections ?verbose ?log_disconnects ?buffer_age_limit ~port =
+  let create ?max_pending_connections
+      ?verbose
+      ?log_disconnects
+      ?buffer_age_limit ~port () =
     ChunkController.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port
+      ?buffer_age_limit ~port ()
     >>| function t -> { sub = t }
 
   let listen t =

--- a/async/Async_OpenFlowChunk.ml
+++ b/async/Async_OpenFlowChunk.ml
@@ -86,9 +86,12 @@ module Controller = struct
         >>| ensure
       | _ -> return (Some(evt))
 
-  let create ?max_pending_connections ?verbose ?log_disconnects ?buffer_age_limit ~port =
+  let create ?max_pending_connections
+      ?verbose
+      ?log_disconnects
+      ?buffer_age_limit ~port () =
     Platform.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port
+      ?buffer_age_limit ~port ()
     >>| function t -> {
       platform = t;
       handshakes = SwitchSet.empty

--- a/async/Async_OpenFlow_Platform.ml
+++ b/async/Async_OpenFlow_Platform.ml
@@ -23,6 +23,7 @@ module type S = sig
     -> ?log_disconnects:bool
     -> ?buffer_age_limit:[ `At_most of Time.Span.t | `Unlimited ]
     -> port:int
+    -> unit
     -> t Deferred.t
 
   val listen : t -> e Pipe.Reader.t
@@ -88,8 +89,10 @@ module Make(Message : Message) = struct
     | `Message of Client_id.t * m
   ]
 
-  let create ?max_pending_connections ?verbose ?log_disconnects
-    ?buffer_age_limit ~port =
+  let create ?max_pending_connections
+      ?verbose
+      ?log_disconnects
+      ?buffer_age_limit ~port () =
     Impl.create ?max_pending_connections ?verbose ?log_disconnects
       ?buffer_age_limit ~port ~auth:(fun _ _ -> return `Allow) ()
 

--- a/examples/Learning_Switch.ml
+++ b/examples/Learning_Switch.ml
@@ -120,7 +120,7 @@ let switch
 
 let main () =
   let open OF0x01Controller in
-  create 6633
+  create 6633 ()
   >>= fun t ->
     Pipe.fold (listen t) ~init:SwitchTable.empty ~f:(switch t)
 


### PR DESCRIPTION
Functions with all named arguments behave oddly unless you pass them
literal values. Adding a dummy unit argument avoids this problem, and it
seems as though this is the reason why Jane Street wrote the Typed_tcp
API in that way.
