### PR TITLE
Use int64 for switchId type

### DIFF
--- a/lib/SDN_Types.ml
+++ b/lib/SDN_Types.ml
@@ -11,7 +11,7 @@ type int64 = Int64.t
 type int48 = Int64.t
 type bytes = Cstruct.t
 
-type switchId = VInt.t
+type switchId = int64
 type portId = VInt.t
 type queueId = VInt.t
 

--- a/lib/SDN_Types.mli
+++ b/lib/SDN_Types.mli
@@ -37,7 +37,7 @@ type int64 = Int64.t
 type int48 = Int64.t
 type bytes = Cstruct.t
 
-type switchId = VInt.t
+type switchId = int64
 type portId = VInt.t
 type queueId = VInt.t
 

--- a/lwt/HighLevelSwitch0x01.ml
+++ b/lwt/HighLevelSwitch0x01.ml
@@ -16,7 +16,7 @@ let features (sw : t) : AL.switchFeatures =
   let open OpenFlow0x01.SwitchFeatures in
   let from_portDesc desc =
     VInt.Int16 desc.OpenFlow0x01.PortDescription.port_no in
-  { AL.switch_id = VInt.Int64 feats.switch_id;
+  { AL.switch_id = feats.switch_id;
     AL.switch_ports = List.map from_portDesc feats.ports }
 
 let from_handle (switch : Switch.t) : t =

--- a/lwt/HighLevelSwitch0x04.ml
+++ b/lwt/HighLevelSwitch0x04.ml
@@ -20,7 +20,7 @@ let features (sw : t) : AL.switchFeatures =
   let open OpenFlow0x04.SwitchFeatures in
   let from_portDesc desc =
     VInt.Int32 desc.Core.port_no in
-  { AL.switch_id = VInt.Int64 feats.datapath_id;
+  { AL.switch_id = feats.datapath_id;
     AL.switch_ports = List.map from_portDesc ports }
 
 let from_handle (switch : Switch.t) : t =


### PR DESCRIPTION
A switch id is 64 bits across protocol versions, so just use that.
