### PR TITLE
Make tests return non-zero status on failure

### DIFF
--- a/test/Test.ml
+++ b/test/Test.ml
@@ -163,3 +163,5 @@ module RoundTripping = struct
     | _ -> 
       false
 end
+
+Pa_ounit_lib.Runtime.summarize ()


### PR DESCRIPTION
All the test were being run properly, and failures could be locally observed by reading console output. However, the travis-ci script was assuming that the tests would return a non-zero status code on failure,
which was not happening.

In order to correct this, the following line was added to the bottom of tests/Test.ml:

```
  Pa_ounit_lib.Runtime.summarize ()
```

As the name implies, this will summarize the results of the test run and in addition return a non-zero status if any tests failed.
