### PR TITLE
 Use int32 for payload buffer id in the abstraction layer

### DIFF
--- a/lib/SDN_OpenFlow0x01.ml
+++ b/lib/SDN_OpenFlow0x01.ml
@@ -3,18 +3,12 @@ module Core = OpenFlow0x01_Core
 module Msg = OpenFlow0x01.Message
 module Fields = AL.FieldMap
 
-let from_buffer_id (bufId : AL.bufferId) : int32 =
-  let open SDN_Types in
-  match bufId with
-    | OF10BufferId n -> n
-    | OF13BufferId _ ->
-      raise (Invalid_argument "expected OpenFlow 1.0 buffer ID")
-  
+
 let to_payload (pay : Core.payload) : AL.payload =
   let open Core in
   match pay with
     | Buffered (buf_id, ct) ->
-      AL.Buffered (AL.OF10BufferId buf_id, ct)
+      AL.Buffered (buf_id, ct)
     | NotBuffered ct ->
       AL.NotBuffered ct
   
@@ -22,7 +16,7 @@ let from_payload (pay : AL.payload) : Core.payload =
   let open SDN_Types in
   match pay with
     | Buffered (buf_id, bytes) ->
-      Core.Buffered (from_buffer_id buf_id, bytes)
+      Core.Buffered (buf_id, bytes)
     | NotBuffered bytes -> Core.NotBuffered bytes
       
 let to_reason (reason : Core.packetInReason) : AL.packetInReason =

--- a/lib/SDN_OpenFlow0x01.mli
+++ b/lib/SDN_OpenFlow0x01.mli
@@ -1,4 +1,3 @@
-val from_buffer_id : SDN_Types.bufferId -> int32
 val to_payload : OpenFlow0x01_Core.payload -> SDN_Types.payload
 val from_payload : SDN_Types.payload -> OpenFlow0x01_Core.payload
 val to_reason : OpenFlow0x01_Core.packetInReason -> SDN_Types.packetInReason

--- a/lib/SDN_OpenFlow0x04.ml
+++ b/lib/SDN_OpenFlow0x04.ml
@@ -3,18 +3,12 @@ module Core = OpenFlow0x04_Core
 module Msg = OpenFlow0x04.Message
 module Fields = AL.FieldMap
 
-let from_buffer_id (bufId : AL.bufferId) : int32 =
-  let open SDN_Types in
-  match bufId with
-    | OF13BufferId n -> n
-    | OF10BufferId _ ->
-      raise (Invalid_argument "expected OpenFlow 1.3 buffer ID")
-  
+
 let to_payload (pay : Core.payload) : AL.payload =
   let open Core in
   match pay with
     | Buffered (buf_id, ct) ->
-      AL.Buffered (AL.OF10BufferId buf_id, ct)
+      AL.Buffered (buf_id, ct)
     | NotBuffered ct ->
       AL.NotBuffered ct
   
@@ -22,7 +16,7 @@ let from_payload (pay : AL.payload) : Core.payload =
   let open SDN_Types in
   match pay with
     | Buffered (buf_id, bytes) ->
-      Core.Buffered (from_buffer_id buf_id, bytes)
+      Core.Buffered (buf_id, bytes)
     | NotBuffered bytes -> Core.NotBuffered bytes
       
 let to_reason (reason : Core.packetInReason) : AL.packetInReason =

--- a/lib/SDN_Types.ml
+++ b/lib/SDN_Types.ml
@@ -15,9 +15,7 @@ type switchId = int64
 type portId = VInt.t
 type queueId = VInt.t
 
-type bufferId =
-  | OF10BufferId of int32
-  | OF13BufferId of OF13.bufferId
+type bufferId = int32
 
 type field =
   | InPort

--- a/lib/SDN_Types.mli
+++ b/lib/SDN_Types.mli
@@ -41,9 +41,7 @@ type switchId = int64
 type portId = VInt.t
 type queueId = VInt.t
 
-type bufferId =
-  | OF10BufferId of int32
-  | OF13BufferId of OpenFlow0x04_Core.bufferId
+type bufferId = int32
 
 exception Unsupported of string
 

--- a/quickcheck/Arbitrary_SDN_Types.ml
+++ b/quickcheck/Arbitrary_SDN_Types.ml
@@ -8,12 +8,7 @@ let arbitrary_bytes max_len =
   choose_int32 (Int32.zero, Int32.of_int max_len) >>= fun l ->
     ret_gen (Cstruct.create (Int32.to_int l))
 
-let arbitrary_bufferId =
-  let open Gen in
-  arbitrary_int >>= (fun id ->
-    oneof [
-      ret_gen (SDN_Types.OF10BufferId (Int32.of_int id));
-      ret_gen (SDN_Types.OF13BufferId (Int32.of_int id))])
+let arbitrary_bufferId = Arbitrary_Base.arbitrary_uint32
 
 let arbitrary_payload =
   let open Gen in


### PR DESCRIPTION
It's the same across OpenFlow versions, so just use int32.
