### PR TITLE
adding Table/OFPP to pseudoPort

### DIFF
--- a/lib/OpenFlow0x01.ml
+++ b/lib/OpenFlow0x01.ml
@@ -359,6 +359,7 @@ module PseudoPort = struct
     | AllPorts -> ofp_port_to_int OFPP_ALL
     (* see wall of text above *)
     | Controller _ -> ofp_port_to_int OFPP_CONTROLLER 
+    | Table -> ofp_port_to_int OFPP_TABLE
 
   let marshal_optional (t : t option) : int = match t with
     | None -> ofp_port_to_int OFPP_NONE
@@ -370,12 +371,14 @@ module PseudoPort = struct
     | Flood -> "Flood"
     | AllPorts -> "AllPorts"
     | Controller n -> sprintf "Controller<%d bytes>" n
+    | Table -> "Table"
 
   let make ofp_port_code len =
     match int_to_ofp_port ofp_port_code with
       | Some OFPP_IN_PORT -> InPort
       | Some OFPP_FLOOD -> Flood
       | Some OFPP_ALL -> AllPorts
+      | Some OFPP_TABLE -> Table
       | Some OFPP_CONTROLLER -> Controller len
       | _ ->
         if ofp_port_code <= (ofp_port_to_int OFPP_MAX) then

--- a/lib/OpenFlow0x01_Core.ml
+++ b/lib/OpenFlow0x01_Core.ml
@@ -30,6 +30,7 @@ type pseudoPort =
   | InPort
   | Flood
   | Controller of int
+  | Table
 
 type action =
   | Output of pseudoPort

--- a/lib/OpenFlow0x01_Core.mli
+++ b/lib/OpenFlow0x01_Core.mli
@@ -62,6 +62,7 @@ type pseudoPort =
               STP. *)
   | Controller of int (** Send to controller along with [n] (max 1024)
                           bytes of the packet. *)
+  | Table (** Send the packet out packet through the table *)
 
 (** Flow action data structure.  See Section 5.2.4 of the OpenFlow 1.0
     specification. *)


### PR DESCRIPTION
Adds support for the pseudoPort OFPP_Table.  (necessary to make pox's l2_multi work...else it faults on /lib/OpenFlow0x01.ml#L385)
