### PR TITLE
Extended logging interface

### DIFF
--- a/async/Async_OpenFlow.mli
+++ b/async/Async_OpenFlow.mli
@@ -10,6 +10,8 @@ module Log : sig
   val make_filtered_output : (string * string) list ->
     Log.Output.t
 
+  val add_output : Log.Output.t list -> unit
+
 end
 
 module type Message = sig

--- a/async/Async_OpenFlow_Log.ml
+++ b/async/Async_OpenFlow_Log.ml
@@ -39,6 +39,8 @@ let make_filtered_output (tags : (string * string) list)
          Writer.write writer (label_severity msg);
          Writer.newline writer)))
 
+let current_outputs = ref []
+
 let stderr : Log.Output.t =
   make_filtered_output [("openflow", "")]
 
@@ -46,7 +48,13 @@ let log = lazy (Log.create ~level:`Info ~output:[stderr])
 
 let set_level = Log.set_level (Lazy.force log)
 
-let set_output = Log.set_output (Lazy.force log)
+let set_output outputs = current_outputs := outputs;
+  Log.set_output (Lazy.force log) outputs
+
+let add_output outputs =
+  let outputs = outputs @ !current_outputs in
+  current_outputs := outputs;
+  set_output outputs
 
 let raw ?(tags=[]) fmt = Log.raw (Lazy.force log) ~tags fmt
 


### PR DESCRIPTION
Added add_output method that extends the active outputs instead of overwriting them. Useful for apps that want to add log outputs while retaining the output of the controller.
