### PR TITLE
Trivial fix for Async 111.13.00

### DIFF
--- a/async/Async_OpenFlow_Platform.ml
+++ b/async/Async_OpenFlow_Platform.ml
@@ -94,7 +94,7 @@ module Make(Message : Message) = struct
       ?log_disconnects
       ?buffer_age_limit ~port () =
     Impl.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port ~auth:(fun _ _ -> return `Allow) ()
+      ?buffer_age_limit ~port ~auth:(fun _ _ _ -> return `Allow) ()
 
   let listen t =
     let open Impl.Server_read_result in


### PR DESCRIPTION
This epic one-character commit fixes #123

@seliopou not sure if we want to bump the version of Async required or not. However, 111.13.00 is what's in OPAM these days... 
