### PR TITLE
stability-related changes

### DIFF
--- a/async/Async_OpenFlow.mli
+++ b/async/Async_OpenFlow.mli
@@ -49,6 +49,7 @@ module Platform : sig
       -> ?verbose:bool
       -> ?log_disconnects:bool
       -> ?buffer_age_limit:[ `At_most of Time.Span.t | `Unlimited ]
+      -> ?monitor_connections:bool
       -> port:int
       -> unit
       -> t Deferred.t

--- a/async/Async_OpenFlow0x01.ml
+++ b/async/Async_OpenFlow0x01.ml
@@ -84,9 +84,10 @@ module Controller = struct
   let create ?max_pending_connections
       ?verbose
       ?log_disconnects
-      ?buffer_age_limit ~port () =
+      ?buffer_age_limit
+      ?monitor_connections ~port () =
     ChunkController.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port ()
+      ?buffer_age_limit ?monitor_connections ~port ()
     >>| function t ->
         { sub = t
         ; shakes = ClientSet.empty

--- a/async/Async_OpenFlow0x04.ml
+++ b/async/Async_OpenFlow0x04.ml
@@ -60,9 +60,10 @@ module Controller = struct
   let create ?max_pending_connections
       ?verbose
       ?log_disconnects
-      ?buffer_age_limit ~port () =
+      ?buffer_age_limit
+      ?monitor_connections ~port () =
     ChunkController.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port ()
+      ?buffer_age_limit ?monitor_connections ~port ()
     >>| function t -> { sub = t }
 
   let listen t =

--- a/async/Async_OpenFlowChunk.ml
+++ b/async/Async_OpenFlowChunk.ml
@@ -168,9 +168,10 @@ module Controller = struct
   let create ?max_pending_connections
       ?verbose
       ?log_disconnects
-      ?buffer_age_limit ~port () =
+      ?buffer_age_limit
+      ?(monitor_connections=false) ~port () =
     Platform.create ?max_pending_connections ?verbose ?log_disconnects
-      ?buffer_age_limit ~port ()
+      ?buffer_age_limit ~monitor_connections ~port ()
     >>| function t ->
       let ctl = {
         platform = t;
@@ -179,8 +180,10 @@ module Controller = struct
         idle_wait = Time.Span.of_sec 5.0;
         kill_wait = Time.Span.of_sec 3.0;
       } in
-      Mon.mark_idle ctl;
-      Mon.kill_idle ctl;
+      if monitor_connections then begin
+        Mon.mark_idle ctl;
+        Mon.kill_idle ctl
+      end;
       ctl
 
   let listen t = Platform.listen t.platform

--- a/async/Async_OpenFlow_Platform.ml
+++ b/async/Async_OpenFlow_Platform.ml
@@ -24,6 +24,7 @@ module type S = sig
     -> ?verbose:bool
     -> ?log_disconnects:bool
     -> ?buffer_age_limit:[ `At_most of Time.Span.t | `Unlimited ]
+    -> ?monitor_connections:bool
     -> port:int
     -> unit
     -> t Deferred.t
@@ -103,7 +104,9 @@ module Make(Message : Message) = struct
   let create ?max_pending_connections
       ?verbose
       ?log_disconnects
-      ?buffer_age_limit ~port () =
+      ?buffer_age_limit
+      ?monitor_connections
+      ~port () =
     Impl.create ?max_pending_connections ?verbose ?log_disconnects
       ?buffer_age_limit ~port ~auth:(fun _ _ _ -> return `Allow) ()
 


### PR DESCRIPTION
This pull request includes several changes to make it easer to write stable openflow controllers using the library. These include:
- Not raising certain exceptions in `Stage.t`s related to connections that the user is not yet aware of, but instead logging those exceptions for later debugging if necessary;
- Exposing an API for originating echo requests from the controller for monitoring switch connections;
- Detecting closed connections and raising an exception in `send` calls when that happens (in contrast to the previous behavior in which the resultant `Deferred.t` would never become determined.
