### PR TITLE
port_id checking

### DIFF
--- a/lib/SDN_OpenFlow0x04.ml
+++ b/lib/SDN_OpenFlow0x04.ml
@@ -1,4 +1,5 @@
 module Int32 = Core.Std.Int32
+module Int64 = Core.Std.Int64
 
 module AL = SDN_Types
 module Core = OpenFlow0x04_Core
@@ -8,7 +9,7 @@ module Msg = OpenFlow0x04.Message
 exception Invalid_port of Int32.t with sexp
 
 let from_portId (pport_id : AL.portId) : Core.portId =
-  if pport_id > 0xffffff00l then (* pport_id <= OFPP_MAX *)
+  if Int32.to_int64 pport_id > 0xffffff00L then (* pport_id <= OFPP_MAX *)
     raise (Invalid_port pport_id)
   else
     pport_id


### PR DESCRIPTION
This pull request fixes an issue in the translation from the abstraction layer to OpenFlow 1.3 that would identify all physical ports and invalid.
