### PR TITLE
Update logging to use core/async.111.28.00 logging API

### DIFF
--- a/async/Async_OpenFlow.mli
+++ b/async/Async_OpenFlow.mli
@@ -7,6 +7,13 @@ module Log : sig
 
   include Log.Global_intf
 
+  val of_lazy
+    :  ?level:[ `Debug | `Info | `Error ]
+    -> ?time:Time.t
+    -> ?tags:(string * string) list
+    -> string Lazy.t
+    -> unit
+
   val make_filtered_output : (string * string) list ->
     Log.Output.t
 

--- a/async/Async_OpenFlow_Log.ml
+++ b/async/Async_OpenFlow_Log.ml
@@ -46,6 +46,7 @@ let stderr : Log.Output.t =
 
 let log = lazy (Log.create ~level:`Info ~output:[stderr])
 
+let level () = Log.level (Lazy.force log)
 let set_level = Log.set_level (Lazy.force log)
 
 let set_output outputs = current_outputs := outputs;
@@ -56,24 +57,33 @@ let add_output outputs =
   current_outputs := outputs;
   set_output outputs
 
-let raw ?(tags=[]) fmt = Log.raw (Lazy.force log) ~tags fmt
+let raw ?time ?(tags=[]) fmt = Log.raw (Lazy.force log) ?time ~tags fmt
 
-let info ?(tags=[]) fmt = Log.info (Lazy.force log) ~tags fmt
+let info ?time ?(tags=[]) fmt = Log.info (Lazy.force log) ?time ~tags fmt
 
-let error ?(tags=[]) fmt = Log.error (Lazy.force log) ~tags fmt
+let error ?time ?(tags=[]) fmt = Log.error (Lazy.force log) ?time ~tags fmt
 
-let debug ?(tags=[]) fmt = Log.debug (Lazy.force log) ~tags fmt
+let debug ?time ?(tags=[]) fmt = Log.debug (Lazy.force log) ?time ~tags fmt
 
 let flushed () =
   Log.flushed (Lazy.force log)
 
-let printf ?(tags=[]) ?(level=`Debug) fmt =
+let printf ?(level=`Debug) ?time ?(tags=[]) fmt =
   Log.printf (Lazy.force log) ~tags ~level fmt
 
-let of_lazy ?(tags=[]) ?(level=`Debug) lazy_str =
-  Log.of_lazy (Lazy.force log) ~tags ~level lazy_str
+let of_lazy ?(level=`Debug) ?time ?(tags=[]) lazy_str =
+  (* As of core/async.111.25.00, `Log.of_lazy` is no longer part of that
+   * package's public API. In 111.28.00, the `Log.level` call was added,
+   * allowing users of the package to implement `of_lazy` without having to
+   * manage the log level manually.
+   * *)
+  if level = Log.level (Lazy.force log) then
+    Log.printf (Lazy.force log) ~tags ~level "%s" (Lazy.force lazy_str)
 
-let sexp ?(tags=[]) ?(level=`Debug) msg =
-    Log.sexp (Lazy.force log) ~tags ~level msg
+let sexp ?(level=`Debug) ?time ?(tags=[]) msg =
+  Log.sexp (Lazy.force log) ~tags ~level msg
+
+let string ?(level=`Debug) ?time ?(tags=[]) str =
+  Log.string (Lazy.force log) ~tags ~level str
 
 let message = Log.message (Lazy.force log)


### PR DESCRIPTION
As of core/async.111.25.00, `Log.of_lazy` is no longer part of package's public API. In 111.28.00, the `Log.level` call was allowing users of the package to implement `of_lazy` without to manage the log level manually. In addition, new optional arguments were introduced along with a `Log.string` call. This is all now part of the public API of the `Async_OpenFlow` module.

Closes #148.
