### PR TITLE
ip_to_mask fix:

### DIFF
--- a/lib/OpenFlow0x04_Core.ml
+++ b/lib/OpenFlow0x04_Core.ml
@@ -19,7 +19,9 @@ let val_to_mask v =
 
 let ip_to_mask (p,m) =
   if m = 32l then { m_value = p; m_mask = None }
-  else { m_value = p; m_mask = Some m }
+  else 
+    let m = Int32.shift_left 0xffffffffl (Int32.to_int (Int32.sub 32l m)) in
+    { m_value = p; m_mask = Some m }
 
 type switchId = int64
 


### PR DESCRIPTION
convert m \in [0,32] to int32 X where the m MSB are set to 1

related to #172 for OF1.3

(OF1.4 is in an other branch)
